### PR TITLE
Fix welcome mute strong to not ban user

### DIFF
--- a/tg_bot/modules/welcome.py
+++ b/tg_bot/modules/welcome.py
@@ -175,7 +175,7 @@ def new_member(bot: Bot, update: Update, job_queue: JobQueue):
 
         if welc_mutes == "strong":
             new_join_mem = f"[{escape_markdown(new_mem.first_name)}](tg://user?id={user.id})"
-            message = msg.reply_text(f"{new_join_mem}, click the button below to prove you're human.\nYou have 120 seconds.",
+            message = msg.reply_text(f"{new_join_mem}, click the button below to prove you're human.\nYou have 30 seconds.",
                                      reply_markup=InlineKeyboardMarkup([{InlineKeyboardButton(
                                          text="Yes, I'm human.",
                                          callback_data=f"user_join_({new_mem.id})")}]),
@@ -190,7 +190,7 @@ def new_member(bot: Bot, update: Update, job_queue: JobQueue):
                 partial(
                     check_not_bot, new_mem, chat.id, message.message_id,
                     update, res, keyboard, backup_message, should_welc
-                ), 10, name="wlcmute"
+                ), 30, name="wlcmute"
             )
 
         if welcome_log:
@@ -227,7 +227,7 @@ def check_not_bot(member, chat_id, message_id,
 
     else:
         try:
-            bot.kick_chat_member(chat_id, member.id)
+            bot.unban_chat_member(chat_id, member.id)
         except:
             pass
 


### PR DESCRIPTION
fixed welcomemute strong, not it doesn't ban the member, instead kicks them after a timeout of 30 secs if they fail to prove they're human by clicking the button.