### PR TITLE
Treewide: use identity for comparison with None

### DIFF
--- a/SaitamaRobot/modules/anime.py
+++ b/SaitamaRobot/modules/anime.py
@@ -350,7 +350,7 @@ def user(update: Update, context: CallbackContext):
     user_joined_date_formatted = user_joined_date.strftime(date_format)
 
     for entity in user:
-        if user[entity] == None:
+        if user[entity] is None:
             user[entity] = "Unknown"
 
     about = user['about'].split(" ", 60)

--- a/SaitamaRobot/modules/blacklist_stickers.py
+++ b/SaitamaRobot/modules/blacklist_stickers.py
@@ -119,7 +119,7 @@ def add_blackliststicker(update: Update, context: CallbackContext):
     elif msg.reply_to_message:
         added = 0
         trigger = msg.reply_to_message.sticker.set_name
-        if trigger == None:
+        if trigger is None:
             send_message(update.effective_message, "Sticker is invalid!")
             return
         try:
@@ -212,7 +212,7 @@ def unblackliststicker(update: Update, context: CallbackContext):
                 parse_mode=ParseMode.HTML)
     elif msg.reply_to_message:
         trigger = msg.reply_to_message.sticker.set_name
-        if trigger == None:
+        if trigger is None:
             send_message(update.effective_message, "Sticker is invalid!")
             return
         success = sql.rm_from_stickers(chat_id, trigger.lower())

--- a/SaitamaRobot/modules/feds.py
+++ b/SaitamaRobot/modules/feds.py
@@ -1639,7 +1639,7 @@ def fed_stat_user(update: Update, context: CallbackContext):
                     "Fed {} not found!".format(fed_id),
                     parse_mode="markdown")
                 return
-            if user_name == "" or user_name == None:
+            if user_name == "" or user_name is None:
                 user_name = "He/she"
             if not reason:
                 send_message(
@@ -1657,7 +1657,7 @@ def fed_stat_user(update: Update, context: CallbackContext):
                 user_name = bot.get_chat(user_id).first_name
             except BadRequest:
                 user_name = "He/she"
-            if user_name == "" or user_name == None:
+            if user_name == "" or user_name is None:
                 user_name = "He/she"
         if len(fbanlist) == 0:
             send_message(
@@ -1970,7 +1970,7 @@ def is_user_fed_owner(fed_id, user_id):
     if getsql == False:
         return False
     getfedowner = eval(getsql['fusers'])
-    if getfedowner == None or getfedowner == False:
+    if getfedowner is None or getfedowner == False:
         return False
     getfedowner = getfedowner['owner']
     if str(user_id) == getfedowner or int(user_id) == OWNER_ID:

--- a/SaitamaRobot/modules/feds.py
+++ b/SaitamaRobot/modules/feds.py
@@ -116,7 +116,7 @@ def del_fed(update: Update, context: CallbackContext):
     if args:
         is_fed_id = args[0]
         getinfo = sql.get_fed_info(is_fed_id)
-        if getinfo == False:
+        if getinfo is False:
             update.effective_message.reply_text(
                 "This federation does not exist.")
             return
@@ -130,7 +130,7 @@ def del_fed(update: Update, context: CallbackContext):
         update.effective_message.reply_text("What should I delete?")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only federation owners can do this!")
         return
@@ -207,7 +207,7 @@ def join_fed(update: Update, context: CallbackContext):
 
     if len(args) >= 1:
         getfed = sql.search_fed_by_id(args[0])
-        if getfed == False:
+        if getfed is False:
             message.reply_text("Please enter a valid federation ID")
             return
 
@@ -248,7 +248,7 @@ def leave_fed(update: Update, context: CallbackContext):
     # administrators = chat.get_administrators().status
     getuser = bot.get_chat_member(chat.id, user.id).status
     if getuser in 'creator' or user.id in SUDO_USERS:
-        if sql.chat_leave_fed(chat.id) == True:
+        if sql.chat_leave_fed(chat.id) is True:
             get_fedlog = sql.get_fed_log(fed_id)
             if get_fedlog:
                 if eval(get_fedlog):
@@ -365,13 +365,13 @@ def user_demote_fed(update: Update, context: CallbackContext):
             )
             return
 
-        if sql.search_user_in_fed(fed_id, user_id) == False:
+        if sql.search_user_in_fed(fed_id, user_id) is False:
             update.effective_message.reply_text(
                 "I cannot demote people who are not federation admins!")
             return
 
         res = sql.user_demote_fed(fed_id, user_id)
-        if res == True:
+        if res is True:
             update.effective_message.reply_text("Demoted from a Fed Admin!")
         else:
             update.effective_message.reply_text("Demotion failed!")
@@ -397,7 +397,7 @@ def fed_info(update: Update, context: CallbackContext):
             return
         info = sql.get_fed_info(fed_id)
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only a federation admin can do this!")
         return
@@ -447,7 +447,7 @@ def fed_admin(update: Update, context: CallbackContext):
             "This group is not in any federation!")
         return
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only federation admins can do this!")
         return
@@ -498,7 +498,7 @@ def fed_ban(update: Update, context: CallbackContext):
     info = sql.get_fed_info(fed_id)
     getfednotif = sql.user_feds_report(info['owner'])
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only federation admins can do this!")
         return
@@ -518,11 +518,11 @@ def fed_ban(update: Update, context: CallbackContext):
             "What is funnier than kicking the group creator? Self sacrifice.")
         return
 
-    if is_user_fed_owner(fed_id, user_id) == True:
+    if is_user_fed_owner(fed_id, user_id) is True:
         message.reply_text("Why did you try the federation fban?")
         return
 
-    if is_user_fed_admin(fed_id, user_id) == True:
+    if is_user_fed_admin(fed_id, user_id) is True:
         message.reply_text("He is a federation admin, I can't fban him.")
         return
 
@@ -825,7 +825,7 @@ def unfban(update: Update, context: CallbackContext):
     info = sql.get_fed_info(fed_id)
     getfednotif = sql.user_feds_report(info['owner'])
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only federation admins can do this!")
         return
@@ -865,7 +865,7 @@ def unfban(update: Update, context: CallbackContext):
         user_target = fban_user_name
 
     fban, fbanreason, fbantime = sql.get_fban_user(fed_id, fban_user_id)
-    if fban == False:
+    if fban is False:
         message.reply_text("This user is not fbanned!")
         return
 
@@ -974,7 +974,7 @@ def unfban(update: Update, context: CallbackContext):
 	FEDADMIN = sql.all_fed_users(fed_id)
 	for x in FEDADMIN:
 		getreport = sql.user_feds_report(x)
-		if getreport == False:
+		if getreport is False:
 			FEDADMIN.remove(x)
 	send_to_list(bot, FEDADMIN,
 			 "<b>Un-FedBan</b>" \
@@ -1006,7 +1006,7 @@ def set_frules(update: Update, context: CallbackContext):
             "This group is not in any federation!")
         return
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text("Only fed admins can do this!")
         return
 
@@ -1083,7 +1083,7 @@ def fed_broadcast(update: Update, context: CallbackContext):
         chat = update.effective_chat
         fed_id = sql.get_fed_id(chat.id)
         fedinfo = sql.get_fed_info(fed_id)
-        if is_user_fed_owner(fed_id, user.id) == False:
+        if is_user_fed_owner(fed_id, user.id) is False:
             update.effective_message.reply_text(
                 "Only federation owners can do this!")
             return
@@ -1148,7 +1148,7 @@ def fed_ban_list(update: Update, context: CallbackContext):
             "This group is not a part of any federation!")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only Federation owners can do this!")
         return
@@ -1244,7 +1244,7 @@ def fed_ban_list(update: Update, context: CallbackContext):
         len(getfban), info['fname'])
     for users in getfban:
         getuserinfo = sql.get_all_fban_users_target(fed_id, users)
-        if getuserinfo == False:
+        if getuserinfo is False:
             text = "There are no users banned from the federation {}".format(
                 info['fname'])
             break
@@ -1339,7 +1339,7 @@ def fed_chats(update: Update, context: CallbackContext):
             "This group is not a part of any federation!")
         return
 
-    if is_user_fed_admin(fed_id, user.id) == False:
+    if is_user_fed_admin(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only federation admins can do this!")
         return
@@ -1397,7 +1397,7 @@ def fed_import_bans(update: Update, context: CallbackContext):
             "This group is not a part of any federation!")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         update.effective_message.reply_text(
             "Only Federation owners can do this!")
         return
@@ -1467,10 +1467,10 @@ def fed_import_bans(update: Update, context: CallbackContext):
                     if int(import_userid) == bot.id:
                         failed += 1
                         continue
-                    if is_user_fed_owner(fed_id, import_userid) == True:
+                    if is_user_fed_owner(fed_id, import_userid) is True:
                         failed += 1
                         continue
-                    if is_user_fed_admin(fed_id, import_userid) == True:
+                    if is_user_fed_admin(fed_id, import_userid) is True:
                         failed += 1
                         continue
                     if str(import_userid) == str(OWNER_ID):
@@ -1536,10 +1536,10 @@ def fed_import_bans(update: Update, context: CallbackContext):
                     if int(import_userid) == bot.id:
                         failed += 1
                         continue
-                    if is_user_fed_owner(fed_id, import_userid) == True:
+                    if is_user_fed_owner(fed_id, import_userid) is True:
                         failed += 1
                         continue
-                    if is_user_fed_admin(fed_id, import_userid) == True:
+                    if is_user_fed_admin(fed_id, import_userid) is True:
                         failed += 1
                         continue
                     if str(import_userid) == str(OWNER_ID):
@@ -1633,7 +1633,7 @@ def fed_stat_user(update: Update, context: CallbackContext):
                 fbantime = time.strftime("%d/%m/%Y", time.localtime(fbantime))
             else:
                 fbantime = "Unavaiable"
-            if user_name == False:
+            if user_name is False:
                 send_message(
                     update.effective_message,
                     "Fed {} not found!".format(fed_id),
@@ -1802,13 +1802,13 @@ def subs_feds(update: Update, context: CallbackContext):
                      "This group is not in any federation!")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         send_message(update.effective_message, "Only fed owner can do this!")
         return
 
     if args:
         getfed = sql.search_fed_by_id(args[0])
-        if getfed == False:
+        if getfed is False:
             send_message(update.effective_message,
                          "Please enter a valid federation id.")
             return
@@ -1858,13 +1858,13 @@ def unsubs_feds(update: Update, context: CallbackContext):
                      "This group is not in any federation!")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         send_message(update.effective_message, "Only fed owner can do this!")
         return
 
     if args:
         getfed = sql.search_fed_by_id(args[0])
-        if getfed == False:
+        if getfed is False:
             send_message(update.effective_message,
                          "Please enter a valid federation id.")
             return
@@ -1914,7 +1914,7 @@ def get_myfedsubs(update: Update, context: CallbackContext):
                      "This group is not in any federation!")
         return
 
-    if is_user_fed_owner(fed_id, user.id) == False:
+    if is_user_fed_owner(fed_id, user.id) is False:
         send_message(update.effective_message, "Only fed owner can do this!")
         return
 
@@ -1957,7 +1957,7 @@ def get_myfeds_list(update: Update, context: CallbackContext):
 
 def is_user_fed_admin(fed_id, user_id):
     fed_admins = sql.all_fed_users(fed_id)
-    if fed_admins == False:
+    if fed_admins is False:
         return False
     if int(user_id) in fed_admins or int(user_id) == OWNER_ID:
         return True
@@ -1967,10 +1967,10 @@ def is_user_fed_admin(fed_id, user_id):
 
 def is_user_fed_owner(fed_id, user_id):
     getsql = sql.get_fed_info(fed_id)
-    if getsql == False:
+    if getsql is False:
         return False
     getfedowner = eval(getsql['fusers'])
-    if getfedowner is None or getfedowner == False:
+    if getfedowner is None or getfedowner is False:
         return False
     getfedowner = getfedowner['owner']
     if str(user_id) == getfedowner or int(user_id) == OWNER_ID:
@@ -2028,7 +2028,7 @@ def __user_info__(user_id, chat_id):
 # Temporary data
 def put_chat(chat_id, value, chat_data):
     # print(chat_data)
-    if value == False:
+    if value is False:
         status = False
     else:
         status = True

--- a/SaitamaRobot/modules/gtranslator.py
+++ b/SaitamaRobot/modules/gtranslator.py
@@ -41,7 +41,7 @@ def totranslate(update: Update, context: CallbackContext):
                         dest_lang = source_lang
                         source_lang = None
                         break
-                if dest_lang == None:
+                if dest_lang is None:
                     dest_lang = source_lang.split("-")[1]
                     source_lang = source_lang.split("-")[0]
             else:
@@ -54,7 +54,7 @@ def totranslate(update: Update, context: CallbackContext):
                     text = text.replace(emoji, '')
 
             trl = Translator()
-            if source_lang == None:
+            if source_lang is None:
                 detection = trl.detect(text)
                 tekstr = trl.translate(text, dest=dest_lang)
                 return message.reply_text(
@@ -94,7 +94,7 @@ def totranslate(update: Update, context: CallbackContext):
                         dest_lang = temp_source_lang.split("-")[1]
                         source_lang = temp_source_lang.split("-")[0]
             trl = Translator()
-            if dest_lang == None:
+            if dest_lang is None:
                 detection = trl.detect(text)
                 tekstr = trl.translate(text, dest=source_lang)
                 return message.reply_text(

--- a/SaitamaRobot/modules/purge.py
+++ b/SaitamaRobot/modules/purge.py
@@ -40,7 +40,7 @@ async def purge_messages(event):
 
 @saitama(pattern="^/del$")
 async def delete_messages(event):
-    if event.from_id == None:
+    if event.from_id is None:
         return
 
     if not await user_is_admin(user_id=event.from_id, message=event):

--- a/SaitamaRobot/modules/reporting.py
+++ b/SaitamaRobot/modules/reporting.py
@@ -201,7 +201,7 @@ def __chat_settings__(update, context, chat, chatP, user):
 
 
 def __user_settings__(update, context, user):
-    if sql.user_should_report(user.id) == True:
+    if sql.user_should_report(user.id) is True:
         text = "You will receive reports from chats you're admin."
         keyboard = [[
             InlineKeyboardButton(

--- a/SaitamaRobot/modules/sql/connection_sql.py
+++ b/SaitamaRobot/modules/sql/connection_sql.py
@@ -190,7 +190,7 @@ def __load_user_history():
         HISTORY_CONNECT = {}
         for x in qall:
             check = HISTORY_CONNECT.get(x.user_id)
-            if check == None:
+            if check is None:
                 HISTORY_CONNECT[x.user_id] = {}
             HISTORY_CONNECT[x.user_id][x.conn_time] = {
                 'chat_name': x.chat_name,

--- a/SaitamaRobot/modules/sql/feds_sql.py
+++ b/SaitamaRobot/modules/sql/feds_sql.py
@@ -117,14 +117,14 @@ MYFEDS_SUBSCRIBER = {}
 
 def get_fed_info(fed_id):
     get = FEDERATION_BYFEDID.get(str(fed_id))
-    if get == None:
+    if get is None:
         return False
     return get
 
 
 def get_fed_id(chat_id):
     get = FEDERATION_CHATS.get(str(chat_id))
-    if get == None:
+    if get is None:
         return False
     else:
         return get['fid']
@@ -132,7 +132,7 @@ def get_fed_id(chat_id):
 
 def get_fed_name(chat_id):
     get = FEDERATION_CHATS.get(str(chat_id))
-    if get == None:
+    if get is None:
         return False
     else:
         return get['chat_name']
@@ -242,7 +242,7 @@ def del_fed(fed_id):
     with FEDS_LOCK:
         global FEDERATION_BYOWNER, FEDERATION_BYFEDID, FEDERATION_BYNAME, FEDERATION_CHATS, FEDERATION_CHATS_BYID, FEDERATION_BANNED_USERID, FEDERATION_BANNED_FULL
         getcache = FEDERATION_BYFEDID.get(fed_id)
-        if getcache == None:
+        if getcache is None:
             return False
         # Variables
         getfed = FEDERATION_BYFEDID.get(fed_id)
@@ -299,7 +299,7 @@ def chat_join_fed(fed_id, chat_name, chat_id):
         SESSION.add(r)
         FEDERATION_CHATS[str(chat_id)] = {'chat_name': chat_name, 'fid': fed_id}
         checkid = FEDERATION_CHATS_BYID.get(fed_id)
-        if checkid == None:
+        if checkid is None:
             FEDERATION_CHATS_BYID[fed_id] = []
         FEDERATION_CHATS_BYID[fed_id].append(str(chat_id))
         SESSION.commit()
@@ -308,14 +308,14 @@ def chat_join_fed(fed_id, chat_name, chat_id):
 
 def search_fed_by_name(fed_name):
     allfed = FEDERATION_BYNAME.get(fed_name)
-    if allfed == None:
+    if allfed is None:
         return False
     return allfed
 
 
 def search_user_in_fed(fed_id, user_id):
     getfed = FEDERATION_BYFEDID.get(fed_id)
-    if getfed == None:
+    if getfed is None:
         return False
     getfed = eval(getfed['fusers'])['members']
     if user_id in eval(getfed):
@@ -419,7 +419,7 @@ def chat_leave_fed(chat_id):
         global FEDERATION_CHATS, FEDERATION_CHATS_BYID
         # Set variables
         fed_info = FEDERATION_CHATS.get(str(chat_id))
-        if fed_info == None:
+        if fed_info is None:
             return False
         fed_id = fed_info['fid']
         # Delete from cache
@@ -437,7 +437,7 @@ def chat_leave_fed(chat_id):
 def all_fed_chats(fed_id):
     with FEDS_LOCK:
         getfed = FEDERATION_CHATS_BYID.get(fed_id)
-        if getfed == None:
+        if getfed is None:
             return []
         else:
             return getfed
@@ -446,7 +446,7 @@ def all_fed_chats(fed_id):
 def all_fed_users(fed_id):
     with FEDS_LOCK:
         getfed = FEDERATION_BYFEDID.get(str(fed_id))
-        if getfed == None:
+        if getfed is None:
             return False
         fed_owner = eval(eval(getfed['fusers'])['owner'])
         fed_admins = eval(eval(getfed['fusers'])['members'])
@@ -575,7 +575,7 @@ def un_fban_user(fed_id, user_id):
 
 def get_fban_user(fed_id, user_id):
     list_fbanned = FEDERATION_BANNED_USERID.get(fed_id)
-    if list_fbanned == None:
+    if list_fbanned is None:
         FEDERATION_BANNED_USERID[fed_id] = []
     if user_id in FEDERATION_BANNED_USERID[fed_id]:
         r = SESSION.query(BansF).all()
@@ -592,14 +592,14 @@ def get_fban_user(fed_id, user_id):
 
 def get_all_fban_users(fed_id):
     list_fbanned = FEDERATION_BANNED_USERID.get(fed_id)
-    if list_fbanned == None:
+    if list_fbanned is None:
         FEDERATION_BANNED_USERID[fed_id] = []
     return FEDERATION_BANNED_USERID[fed_id]
 
 
 def get_all_fban_users_target(fed_id, user_id):
     list_fbanned = FEDERATION_BANNED_FULL.get(fed_id)
-    if list_fbanned == None:
+    if list_fbanned is None:
         FEDERATION_BANNED_FULL[fed_id] = []
         return False
     getuser = list_fbanned[str(user_id)]
@@ -625,7 +625,7 @@ def get_all_feds_users_global():
 
 def search_fed_by_id(fed_id):
     get = FEDERATION_BYFEDID.get(fed_id)
-    if get == None:
+    if get is None:
         return False
     else:
         return get
@@ -639,7 +639,7 @@ def search_fed_by_id(fed_id):
 
 def user_feds_report(user_id: int) -> bool:
     user_setting = FEDERATION_NOTIFICATION.get(str(user_id))
-    if user_setting == None:
+    if user_setting is None:
         user_setting = True
     return user_setting
 
@@ -659,10 +659,10 @@ def set_feds_setting(user_id: int, setting: bool):
 
 def get_fed_log(fed_id):
     fed_setting = FEDERATION_BYFEDID.get(str(fed_id))
-    if fed_setting == None:
+    if fed_setting is None:
         fed_setting = False
         return fed_setting
-    if fed_setting.get('flog') == None:
+    if fed_setting.get('flog') is None:
         return False
     elif fed_setting.get('flog'):
         try:
@@ -760,7 +760,7 @@ def __load_all_feds():
         for x in feds:  # remove tuple by ( ,)
             # Fed by Owner
             check = FEDERATION_BYOWNER.get(x.owner_id)
-            if check == None:
+            if check is None:
                 FEDERATION_BYOWNER[x.owner_id] = []
             FEDERATION_BYOWNER[str(x.owner_id)] = {
                 'fid': str(x.fed_id),
@@ -771,7 +771,7 @@ def __load_all_feds():
             }
             # Fed By FedId
             check = FEDERATION_BYFEDID.get(x.fed_id)
-            if check == None:
+            if check is None:
                 FEDERATION_BYFEDID[x.fed_id] = []
             FEDERATION_BYFEDID[str(x.fed_id)] = {
                 'owner': str(x.owner_id),
@@ -782,7 +782,7 @@ def __load_all_feds():
             }
             # Fed By Name
             check = FEDERATION_BYNAME.get(x.fed_name)
-            if check == None:
+            if check is None:
                 FEDERATION_BYNAME[x.fed_name] = []
             FEDERATION_BYNAME[x.fed_name] = {
                 'fid': str(x.fed_id),
@@ -804,7 +804,7 @@ def __load_all_feds_chats():
         for x in qall:
             # Federation Chats
             check = FEDERATION_CHATS.get(x.chat_id)
-            if check == None:
+            if check is None:
                 FEDERATION_CHATS[x.chat_id] = {}
             FEDERATION_CHATS[x.chat_id] = {
                 'chat_name': x.chat_name,
@@ -812,7 +812,7 @@ def __load_all_feds_chats():
             }
             # Federation Chats By ID
             check = FEDERATION_CHATS_BYID.get(x.fed_id)
-            if check == None:
+            if check is None:
                 FEDERATION_CHATS_BYID[x.fed_id] = []
             FEDERATION_CHATS_BYID[x.fed_id].append(x.chat_id)
     finally:
@@ -827,12 +827,12 @@ def __load_all_feds_banned():
         qall = SESSION.query(BansF).all()
         for x in qall:
             check = FEDERATION_BANNED_USERID.get(x.fed_id)
-            if check == None:
+            if check is None:
                 FEDERATION_BANNED_USERID[x.fed_id] = []
             if int(x.user_id) not in FEDERATION_BANNED_USERID[x.fed_id]:
                 FEDERATION_BANNED_USERID[x.fed_id].append(int(x.user_id))
             check = FEDERATION_BANNED_FULL.get(x.fed_id)
-            if check == None:
+            if check is None:
                 FEDERATION_BANNED_FULL[x.fed_id] = {}
             FEDERATION_BANNED_FULL[x.fed_id][x.user_id] = {
                 'first_name': x.first_name,

--- a/SaitamaRobot/modules/users.py
+++ b/SaitamaRobot/modules/users.py
@@ -126,7 +126,7 @@ def chats(update: Update, context: CallbackContext):
 def chat_checker(update: Update, context: CallbackContext):
     bot = context.bot
     if update.effective_message.chat.get_member(
-            bot.id).can_send_messages == False:
+            bot.id).can_send_messages is False:
         bot.leaveChat(update.effective_message.chat.id)
 
 


### PR DESCRIPTION
According to PEP 8 Comparisons to singletons like None should always be done with is or is not, never the equality operators.  Also Identity checks are faster than equality checks.