### PR TITLE
Treewide: Removed unnecessary f-string's

### DIFF
--- a/SaitamaRobot/modules/currency_converter.py
+++ b/SaitamaRobot/modules/currency_converter.py
@@ -35,7 +35,7 @@ def convert(update: Update, context: CallbackContext):
             current_rate = float(
                 response['Realtime Currency Exchange Rate']['5. Exchange Rate'])
         except KeyError:
-            update.effective_message.reply_text(f"Currency Not Supported.")
+            update.effective_message.reply_text("Currency Not Supported.")
             return
         new_cur_amount = round(orig_cur_amount * current_rate, 5)
         update.effective_message.reply_text(

--- a/SaitamaRobot/modules/dbcleanup.py
+++ b/SaitamaRobot/modules/dbcleanup.py
@@ -101,7 +101,7 @@ def dbcleanup(update: Update, context: CallbackContext):
     reply += f"Total invalid gbanned users - {invalid_gban_count}"
 
     buttons = [[
-        InlineKeyboardButton("Cleanup DB", callback_data=f"db_cleanup")
+        InlineKeyboardButton("Cleanup DB", callback_data="db_cleanup")
     ]]
 
     update.effective_message.reply_text(

--- a/SaitamaRobot/modules/global_bans.py
+++ b/SaitamaRobot/modules/global_bans.py
@@ -224,9 +224,9 @@ def gban(update: Update, context: CallbackContext):
 
     if gban_time > 60:
         gban_time = round((gban_time / 60), 2)
-        message.reply_text(f"Done! Gbanned.", parse_mode=ParseMode.HTML)
+        message.reply_text("Done! Gbanned.", parse_mode=ParseMode.HTML)
     else:
-        message.reply_text(f"Done! Gbanned.", parse_mode=ParseMode.HTML)
+        message.reply_text("Done! Gbanned.", parse_mode=ParseMode.HTML)
 
     try:
         bot.send_message(

--- a/SaitamaRobot/modules/helper_funcs/chat_status.py
+++ b/SaitamaRobot/modules/helper_funcs/chat_status.py
@@ -240,7 +240,7 @@ def bot_can_delete(func):
         message_chat_title = update.effective_message.chat.title
 
         if update_chat_title == message_chat_title:
-            cant_delete = f"I can't delete messages here!\nMake sure I'm admin and can delete other user's messages."
+            cant_delete = "I can't delete messages here!\nMake sure I'm admin and can delete other user's messages."
         else:
             cant_delete = f"I can't delete messages in <b>{update_chat_title}</b>!\nMake sure I'm admin and can delete other user's messages there."
 
@@ -263,7 +263,7 @@ def can_pin(func):
         message_chat_title = update.effective_message.chat.title
 
         if update_chat_title == message_chat_title:
-            cant_pin = f"I can't pin messages here!\nMake sure I'm admin and can pin messages."
+            cant_pin = "I can't pin messages here!\nMake sure I'm admin and can pin messages."
         else:
             cant_pin = f"I can't pin messages in <b>{update_chat_title}</b>!\nMake sure I'm admin and can pin messages there."
 
@@ -287,7 +287,7 @@ def can_promote(func):
         message_chat_title = update.effective_message.chat.title
 
         if update_chat_title == message_chat_title:
-            cant_promote = f"I can't promote/demote people here!\nMake sure I'm admin and can appoint new admins."
+            cant_promote = "I can't promote/demote people here!\nMake sure I'm admin and can appoint new admins."
         else:
             cant_promote = (
                 f"I can't promote/demote people in <b>{update_chat_title}</b>!\n"
@@ -313,7 +313,7 @@ def can_restrict(func):
         message_chat_title = update.effective_message.chat.title
 
         if update_chat_title == message_chat_title:
-            cant_restrict = f"I can't restrict people here!\nMake sure I'm admin and can restrict users."
+            cant_restrict = "I can't restrict people here!\nMake sure I'm admin and can restrict users."
         else:
             cant_restrict = f"I can't restrict people in <b>{update_chat_title}</b>!\nMake sure I'm admin there and can restrict users."
 

--- a/SaitamaRobot/modules/warns.py
+++ b/SaitamaRobot/modules/warns.py
@@ -146,7 +146,7 @@ def button(update: Update, context: CallbackContext) -> str:
             )
         else:
             update.effective_message.edit_text(
-                f"User already has no warns.", parse_mode=ParseMode.HTML)
+                "User already has no warns.", parse_mode=ParseMode.HTML)
 
     return ""
 


### PR DESCRIPTION
It is wasteful to use f-string mechanism if there are no expressions to be extrapolated. It is recommended to use regular strings instead.