### PR TITLE
Updated python runtime to latest stable

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.7
+python-3.8.5


### PR DESCRIPTION
Heroku now supports python 3.8.5 version