### PR TITLE
ping: Minor Anti Pattern code fix

### DIFF
--- a/SaitamaRobot/modules/ping.py
+++ b/SaitamaRobot/modules/ping.py
@@ -56,7 +56,7 @@ def ping_func(to_ping: List[str]) -> List[str]:
 
         pinged_site = f"<b>{each_ping}</b>"
 
-        if each_ping is "Kaizoku" or each_ping is "Kayo":
+        if each_ping == "Kaizoku" or each_ping == "Kayo":
             pinged_site = f'<a href="{sites_list[each_ping]}">{each_ping}</a>'
             ping_time = f"<code>{ping_time} (Status: {r.status_code})</code>"
 


### PR DESCRIPTION
Comparing an object to a literal is usually something you do not want to do, since you can compare to a different literal than what was expected altogether.