### PR TITLE
Revert #338 [anime] Fixed bad url string in /kaizoku responses

### DIFF
--- a/SaitamaRobot/modules/anime.py
+++ b/SaitamaRobot/modules/anime.py
@@ -484,7 +484,7 @@ def site_search(update: Update, context: CallbackContext, site: str):
         if search_result:
             result = f"<b>Search results for</b> <code>{html.escape(search_query)}</code> <b>on</b> <code>AnimeKaizoku</code>: \n"
             for entry in search_result:
-                post_link = entry.a["href"]
+                post_link = "https://animekaizoku.com/" + entry.a["href"]
                 post_name = html.escape(entry.text)
                 result += f"• <a href='{post_link}'>{post_name}</a>\n"
         else:


### PR DESCRIPTION
Yesterday I am getting the result url in bad string https://telegra.ph/file/cbed63d1ec70bd4b0eed6.jpg, thought something wrong in code 🤔. But 
actually that was as error in anime kaizoku website for few days and its fixed now. So reverting.